### PR TITLE
Allow spaces inside struct tags. Trivial.

### DIFF
--- a/tag.go
+++ b/tag.go
@@ -10,7 +10,7 @@ func isValidTag(key string) bool {
 		return false
 	}
 	for _, c := range key {
-		if c != '$' && c != '-' && c != '_' && !unicode.IsLetter(c) && !unicode.IsDigit(c) {
+		if c != ' ' && c != '$' && c != '-' && c != '_' && !unicode.IsLetter(c) && !unicode.IsDigit(c) {
 			return false
 		}
 	}


### PR DESCRIPTION
Summary: While trying to use a bencode'd torrent dictionary, I came across a
key "creation date" and "created by". They cannot be decoded into a struct
since spaces are not considered valid characters in the tag.

Fix that ^^^.
