### PR TITLE
Tags Support

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -285,7 +285,9 @@ func decodeDict(l *lexer, val reflect.Value) error {
 				for i := 0; i < v.NumField(); i++ {
 					f = t.Field(i)
 					tagName, _ := parseTag(f.Tag.Get("bencode"))
-					if tagName == key.val {
+					if tagName == key.val && tagName != "-" {
+						// If we have found a matching tag
+						// that isn't '-'
 						ok = true
 						break
 					}

--- a/decode_test.go
+++ b/decode_test.go
@@ -1,8 +1,8 @@
 package bencode
 
 import (
-	"testing"
 	"reflect"
+	"testing"
 )
 
 type decodeTestCase struct {

--- a/tag.go
+++ b/tag.go
@@ -1,9 +1,9 @@
 package bencode
 
 import (
+	"reflect"
 	"strings"
 	"unicode"
-	"reflect"
 )
 
 // tagOptions is the string following a comma in a struct field's "bencode"
@@ -22,11 +22,8 @@ func parseTag(tag string) (string, tagOptions) {
 // Contains returns whether checks that a comma-separated list of options
 // contains a particular substr flag. substr must be surrounded by a
 // string boundary or commas.
-func (tagOptions tagOptions) Contains(optionName string) bool {
-	if len(tagOptions) == 0 {
-		return false
-	}
-	s := string(tagOptions)
+func (options tagOptions) Contains(optionName string) bool {
+	s := string(options)
 	for s != "" {
 		var next string
 		i := strings.Index(s, ",")
@@ -74,6 +71,6 @@ func isEmptyValue(v reflect.Value) bool {
 	case reflect.Interface, reflect.Ptr:
 		return v.IsNil()
 	}
-	
+
 	return false
 }

--- a/tracer.go
+++ b/tracer.go
@@ -1,8 +1,8 @@
 package bencode
 
 import (
-	"strings"
 	"log"
+	"strings"
 )
 
 var traceDepth int


### PR DESCRIPTION
In this patch I have added tags support in the same style as the Go JSON library.
- Tags are addressed by the key "bencode"
- A value of '-' will omit the field
- A value of 'omitempty' will omit the field if it is nil
- Any other value will be treated as the name of the field
