### PR TITLE
fix panic in encoding unexported fields

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -143,6 +143,11 @@ func encodeValue(w io.Writer, val reflect.Value) error {
 			rkey = reflect.ValueOf(key.Name)
 			fieldValue = v.FieldByIndex(key.Index)
 
+			// filter out unexported values etc.
+			if !fieldValue.CanInterface() {
+				continue
+			}
+
 			/* Tags
 			* Near identical to usage in JSON except with key 'bencode'
 

--- a/encode_test.go
+++ b/encode_test.go
@@ -62,6 +62,7 @@ func TestEncode(t *testing.T) {
 			"a": {0, 1},
 			"b": {2, 3},
 		}, `d1:ali0ei1ee1:bli2ei3eee`, false},
+		{struct{ A, b int }{1, 2}, "d1:Ai1ee", false},
 
 		//raw
 		{RawMessage(`i5e`), `i5e`, false},


### PR DESCRIPTION
I tried encoding a struct with unexported fields and the whole thing blew up with a panic. I made a [Gist for this](https://gist.github.com/keks/a2b63e6cbb2aec667052).

The pull request includes a patch that just ignores those fields. I also provided a test case for this kind of error.

I didn't append myself to the AUTHORS file because I think that would just conflict with the commit in the other pull request. I might be wrong though.
