### PR TITLE
add support for boolean

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -214,6 +214,12 @@ func (d *Decoder) decodeInt(v reflect.Value) error {
 			return err
 		}
 		v.SetUint(n)
+	case reflect.Bool:
+		n, err := strconv.ParseUint(digits, 10, 64)
+		if err != nil {
+			return err
+		}
+		v.SetBool(n != 0)
 	}
 
 	return nil

--- a/decode_test.go
+++ b/decode_test.go
@@ -35,6 +35,11 @@ func TestDecode(t *testing.T) {
 		{`i8e`, new(int64), int64(8), false},
 		{`i-2e`, new(uint), nil, true},
 
+		//bools
+		{`i1e`, new(bool), true, false},
+		{`i0e`, new(bool), false, false},
+		{`i8e`, new(bool), true, false},
+
 		//strings
 		{`3:foo`, new(string), "foo", false},
 		{`4:foob`, new(string), "foob", false},

--- a/encode.go
+++ b/encode.go
@@ -57,6 +57,15 @@ func EncodeString(val interface{}) (string, error) {
 	return buf.String(), nil
 }
 
+func EncodeBool(val interface{}) ([]byte, error) {
+	buf := new(bytes.Buffer)
+	e := NewEncoder(buf)
+	if err := e.Encode(val); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
 //EncodeBytes returns the bencoded data of val as a slice of bytes.
 func EncodeBytes(val interface{}) ([]byte, error) {
 	buf := new(bytes.Buffer)
@@ -84,6 +93,14 @@ func encodeValue(w io.Writer, val reflect.Value) error {
 
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		_, err := fmt.Fprintf(w, "i%de", v.Uint())
+		return err
+
+	case reflect.Bool:
+		i := 0
+		if v.Bool() {
+			i = 1
+		}
+		_, err := fmt.Fprintf(w, "i%de", i)
 		return err
 
 	case reflect.String:
@@ -158,9 +175,9 @@ func encodeValue(w io.Writer, val reflect.Value) error {
 			    option.
 
 			* The default key string is the struct field name but can be
-			  specified in the struct field's tag value.  The "bencode" 
-			  key in struct field's tag value is the key name, followed 
-			  by an optional comma and options. 
+			  specified in the struct field's tag value.  The "bencode"
+			  key in struct field's tag value is the key name, followed
+			  by an optional comma and options.
 			*/
 			tagValue := key.Tag.Get("bencode")
 			if tagValue != "" {

--- a/encode.go
+++ b/encode.go
@@ -57,6 +57,7 @@ func EncodeString(val interface{}) (string, error) {
 	return buf.String(), nil
 }
 
+//EncodeBool returns the bencoded data of val as a bool.
 func EncodeBool(val interface{}) ([]byte, error) {
 	buf := new(bytes.Buffer)
 	e := NewEncoder(buf)

--- a/encode.go
+++ b/encode.go
@@ -57,16 +57,6 @@ func EncodeString(val interface{}) (string, error) {
 	return buf.String(), nil
 }
 
-//EncodeBool returns the bencoded data of val as a bool.
-func EncodeBool(val interface{}) ([]byte, error) {
-	buf := new(bytes.Buffer)
-	e := NewEncoder(buf)
-	if err := e.Encode(val); err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), nil
-}
-
 //EncodeBytes returns the bencoded data of val as a slice of bytes.
 func EncodeBytes(val interface{}) ([]byte, error) {
 	buf := new(bytes.Buffer)

--- a/encode_test.go
+++ b/encode_test.go
@@ -51,6 +51,10 @@ func TestEncode(t *testing.T) {
 			{"c": 2, "d": 3},
 		}, `ld1:ai0e1:bi1eed1:ci2e1:di3eee`, false},
 
+		//boolean
+		{true, "i1e", false},
+		{false, "i0e", false},
+
 		//dicts
 		{map[string]interface{}{
 			"a": "foo",


### PR DESCRIPTION
I know this isn't exactly covered by the official [specs][1], but considering the formality of the specs, I thought it was okay to interpret integer values as `bool` with all values except `0` being `true`. `true` values are encoded as `i1e`.

I was actually just annoyed that encoding boolean values isn't possible.

[1]: http://www.bittorrent.org/beps/bep_0003.html#bencoding