### PR TITLE
Adds support for embedded struct similarly to `encoding/json`

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -231,7 +231,9 @@ func encodeStruct(w io.Writer, v reflect.Value) error {
 		}
 
 		if key.Anonymous && key.Type.Kind() == reflect.Struct && tagValue == "" {
-			encodeStruct(w, fieldValue)
+			if err := encodeStruct(w, fieldValue); err != nil {
+				return err
+			}
 		} else {
 			//encode the key
 			if err := encodeValue(w, rkey); err != nil {

--- a/encode_test.go
+++ b/encode_test.go
@@ -29,6 +29,10 @@ func TestEncode(t *testing.T) {
 		T *issue18Sub
 	}
 
+	type Embedded struct {
+		B string
+	}
+
 	var encodeCases = []encodeTestCase{
 		//integers
 		{10, `i10e`, false},
@@ -107,6 +111,16 @@ func TestEncode(t *testing.T) {
 		{issue18{}, `de`, false},
 		{map[string]interface{}{"a": nil}, `de`, false},
 		{struct{ A interface{} }{nil}, `de`, false},
+
+		// embedded structs
+		{struct {
+			A string
+			Embedded
+		}{"foo", Embedded{"bar"}}, `d1:A3:foo1:B3:bare`, false},
+		{struct {
+			A        string
+			Embedded `bencode:"C"`
+		}{"foo", Embedded{"bar"}}, `d1:A3:foo1:Cd1:B3:baree`, false},
 	}
 
 	for i, tt := range encodeCases {


### PR DESCRIPTION
~~~ Go
type (                                                                                                   
    Embedded struct {                                                                                    
        B string                                                                                         
    }                                                                                                    
    Embedding struct {                                                                                   
        A string                                                                                         
        Embedded                                                                                         
    }                                                                                                    
)

...

str, _ := bencode.EncodeString(Embedding{"foo", Embedded{"bar"}})
str == "d1:A3:foo1:B3:bare"
~~~