### PR TITLE
Fix marshaler detection

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -561,14 +561,12 @@ func (d *Decoder) indirect(v reflect.Value) (Unmarshaler, encoding.TextUnmarshal
 			break
 		}
 
-		if v.Type().NumMethod() > 0 {
-			vi := v.Interface()
-			if u, ok := vi.(Unmarshaler); ok {
-				return u, nil, reflect.Value{}
-			}
-			if u, ok := vi.(encoding.TextUnmarshaler); ok {
-				return nil, u, reflect.Value{}
-			}
+		vi := v.Interface()
+		if u, ok := vi.(Unmarshaler); ok {
+			return u, nil, reflect.Value{}
+		}
+		if u, ok := vi.(encoding.TextUnmarshaler); ok {
+			return nil, u, reflect.Value{}
 		}
 
 		v = v.Elem()

--- a/encode.go
+++ b/encode.go
@@ -228,14 +228,12 @@ func indirectEncodeValue(v reflect.Value) (Marshaler, encoding.TextMarshaler, re
 			break
 		}
 
-		if v.Type().NumMethod() > 0 {
-			vi := v.Interface()
-			if m, ok := vi.(Marshaler); ok {
-				return m, nil, reflect.Value{}
-			}
-			if m, ok := vi.(encoding.TextMarshaler); ok {
-				return nil, m, reflect.Value{}
-			}
+		vi := v.Interface()
+		if m, ok := vi.(Marshaler); ok {
+			return m, nil, reflect.Value{}
+		}
+		if m, ok := vi.(encoding.TextMarshaler); ok {
+			return nil, m, reflect.Value{}
 		}
 
 		if v.Kind() != reflect.Ptr {


### PR DESCRIPTION
Here's a reproducible case:

```
type T []byte

func (x T) MarshalBencode() ([]byte, error) {
	fmt.Println("THIS GOT CALLED")
	return []byte("x"), nil
}

encoded, err := bencode.EncodeBytes([]interface{}{
	T("something"),
})
fmt.Println(encoded)
```

Notice that MarshalBencode() is not called when it should be.

The problem stems from NumMethod() returning 0 for the interface, even though the `vi.(Marshaler)` cast would succeed. Removing that if check fixed the issue for me.